### PR TITLE
fix: really attempt to return _all_ bytes if plain read called

### DIFF
--- a/to_file_like_obj/__init__.py
+++ b/to_file_like_obj/__init__.py
@@ -1,5 +1,5 @@
 from io import IOBase
-from typing import TypeVar, Iterable, Type, Iterator, overload
+from typing import Union, TypeVar, Iterable, Type, Iterator, overload
 
 T = TypeVar('T', str, bytes)
 
@@ -20,7 +20,7 @@ def to_file_like_obj(iterable: Iterable[T], base=bytes) -> IOBase:
     offset: int = 0
     it = iter(iterable)
 
-    def up_to_iter(size: int) -> Iterator[T]:
+    def up_to_iter(size: Union[int, float]) -> Iterator[T]:
         nonlocal chunk, offset
 
         while size:
@@ -31,7 +31,7 @@ def to_file_like_obj(iterable: Iterable[T], base=bytes) -> IOBase:
                     break
                 else:
                     offset = 0
-            to_yield: int = min(size, len(chunk) - offset)
+            to_yield = int(min(size, len(chunk) - offset))
             offset = offset + to_yield
             size -= to_yield
             yield chunk[offset - to_yield : offset]
@@ -41,9 +41,8 @@ def to_file_like_obj(iterable: Iterable[T], base=bytes) -> IOBase:
             return True
 
         def read(self, size: int=-1) -> T:
-            max_size: int = 2**63 - 1
             return base().join(
-                up_to_iter(max_size if size is None or size < 0 else size)
+                up_to_iter(float('inf') if size is None or size < 0 else size)
             )
 
     return FileLikeObj()


### PR DESCRIPTION
The previous behaviour limits a single read to 2^63 - 1 bytes, even if all are requested. However, this is wrong. If all are requested all should be returned.

There is a (strong!) possibility that more bytes than 2^63 - 1 cannot be allocated. But then this is a reason that the function should error - it should not behave as though 2^63 - 1 bytes is the entire stream.

This is probably all academic... I suspect there isn't a system around running Python that could come close to allocating 2^63 - 1 bytes.